### PR TITLE
feat: support vcan in socketcan channel

### DIFF
--- a/pkg/canbus/socketcan.go
+++ b/pkg/canbus/socketcan.go
@@ -60,11 +60,29 @@ func (c *SocketCANChannel) Run(ctx context.Context) error {
 		return fmt.Errorf("no link found for %v: %w", c.options.InterfaceName, err)
 	}
 
-	if link.Type() != "can" {
+	if link.Type() != "can" && link.Type() != "vcan" {
 		return fmt.Errorf("invalid linktype %q", link.Type())
 	}
 
-	canLink := link.(*netlink.Can)
+	var canLink *netlink.Can
+	if link.Type() == "vcan" {
+		if link.Attrs().OperState == netlink.OperDown {
+			c.log.WithField("canName", c.options.InterfaceName).Info("vcan link is down, bringing up link")
+			cmd := exec.CommandContext(ctx, "ip", "link", "set", c.options.InterfaceName, "up") // #nosec G204 -- interface name is argv only.
+			if output, err := cmd.Output(); err != nil {
+				logBase := c.log.WithField("cmd", strings.Join(cmd.Args, " ")).WithField("output", string(output))
+				var exitErr *exec.ExitError
+				if stderrors.As(err, &exitErr) {
+					logBase = logBase.WithField("stderr", string(exitErr.Stderr))
+				}
+				logBase.Error("Ip link set up failed")
+				return err
+			}
+		}
+		goto linkReady
+	}
+
+	canLink = link.(*netlink.Can)
 
 	if canLink.Attrs().OperState == netlink.OperUp {
 		bounce := false
@@ -115,6 +133,8 @@ func (c *SocketCANChannel) Run(ctx context.Context) error {
 		}
 	}
 
+linkReady:
+
 	if c.isClosed() {
 		return nil
 	}
@@ -125,8 +145,11 @@ func (c *SocketCANChannel) Run(ctx context.Context) error {
 		return err
 	}
 
-	busHandler := can.NewHandler(c.options.MessageHandler)
-	bus.Subscribe(busHandler)
+	var busHandler can.Handler
+	if c.options.MessageHandler != nil {
+		busHandler = can.NewHandler(c.options.MessageHandler)
+		bus.Subscribe(busHandler)
+	}
 
 	c.mu.Lock()
 	closed := c.closed
@@ -136,7 +159,9 @@ func (c *SocketCANChannel) Run(ctx context.Context) error {
 	}
 	c.mu.Unlock()
 	if closed {
-		bus.Unsubscribe(busHandler)
+		if busHandler != nil {
+			bus.Unsubscribe(busHandler)
+		}
 		if err := bus.Disconnect(); err != nil && !isClosedCANBusError(err) {
 			return pkgerrors.Wrap(err, "close underlying bus connection")
 		}

--- a/pkg/canbus/socketcan_test.go
+++ b/pkg/canbus/socketcan_test.go
@@ -1,11 +1,17 @@
 package canbus
 
 import (
+	"context"
 	"io"
 	"os"
+	"os/exec"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/brutella/can"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -46,4 +52,110 @@ func TestSocketCANWriteAfterCloseReturnsError(t *testing.T) {
 
 	require.NoError(t, c.Close())
 	require.ErrorContains(t, c.WriteFrame(can.Frame{}), "canbus channel is closed")
+}
+
+func TestSocketCANChannelVCan0WriteFrame(t *testing.T) {
+	requireVCan0(t)
+
+	log := logrus.New()
+	log.SetLevel(logrus.InfoLevel)
+
+	channel := NewSocketCANChannel(log, SocketCANChannelOptions{
+		InterfaceName:        "vcan0",
+		BitRate:              250000,
+		ForceBounceInterface: false,
+		MessageHandler:       func(can.Frame) {},
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- channel.Run(ctx)
+	}()
+
+	waitForSocketCANBus(t, channel, errCh)
+	t.Cleanup(func() {
+		cancel()
+		assert.NoError(t, channel.Close())
+	})
+
+	testFrame := can.Frame{
+		ID:     0x123,
+		Length: 4,
+		Data:   [8]byte{0x01, 0x02, 0x03, 0x04},
+	}
+	assert.NoError(t, channel.WriteFrame(testFrame))
+}
+
+func TestSocketCANChannelVCan0AllowsNilMessageHandler(t *testing.T) {
+	requireVCan0(t)
+
+	log := logrus.New()
+	log.SetLevel(logrus.InfoLevel)
+
+	channel := NewSocketCANChannel(log, SocketCANChannelOptions{
+		InterfaceName:        "vcan0",
+		BitRate:              250000,
+		ForceBounceInterface: false,
+		MessageHandler:       nil,
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- channel.Run(ctx)
+	}()
+
+	waitForSocketCANBus(t, channel, errCh)
+	t.Cleanup(func() {
+		cancel()
+		assert.NoError(t, channel.Close())
+	})
+
+	testFrame := can.Frame{
+		ID:     0x124,
+		Length: 1,
+		Data:   [8]byte{0x01},
+	}
+	assert.NoError(t, channel.WriteFrame(testFrame))
+}
+
+func requireVCan0(t *testing.T) {
+	t.Helper()
+
+	output, err := exec.Command("ip", "link", "show", "vcan0").CombinedOutput()
+	if err != nil {
+		t.Skipf("vcan0 is not available: %v: %s", err, string(output))
+	}
+	if !strings.Contains(string(output), "UP") {
+		t.Skipf("vcan0 is not up: %s", string(output))
+	}
+}
+
+func waitForSocketCANBus(t *testing.T, channel *SocketCANChannel, errCh <-chan error) {
+	t.Helper()
+
+	deadline := time.After(2 * time.Second)
+	tick := time.NewTicker(10 * time.Millisecond)
+	defer tick.Stop()
+
+	for {
+		select {
+		case err := <-errCh:
+			t.Fatalf("SocketCAN channel exited before startup completed: %v", err)
+		case <-deadline:
+			t.Fatal("timed out waiting for SocketCAN channel startup")
+		case <-tick.C:
+			channel.mu.Lock()
+			started := channel.bus != nil
+			channel.mu.Unlock()
+			if started {
+				return
+			}
+		}
+	}
 }


### PR DESCRIPTION
I moved back to adding vcan to socketcan; the cost is minimal and the alternative means a client would have to build a local copy with debugging and use a replace. 